### PR TITLE
Add missing css to properly display footnotes

### DIFF
--- a/design.css
+++ b/design.css
@@ -895,6 +895,10 @@ div.dokuwiki div.fn {
   font-size: 90%;
 }
 
+.dokuwiki div.footnotes div.fn div.content {
+    display: inline;
+}
+
 div.dokuwiki a.fn_bot {
   font-weight: bold;
 }


### PR DESCRIPTION
Footnotes are now displayed inline with the number besides them.

Added newline to end of file for better handling on terminals. 